### PR TITLE
PreCheck Domain to avoid Let's Encrypt Rate Limits

### DIFF
--- a/services.d/certbot/run
+++ b/services.d/certbot/run
@@ -15,6 +15,15 @@ until curl --connect-timeout 1 http://127.0.0.1/; do
 done
 echo Nginx has arrived.
 
+echo Waiting for a response from http://${SERVERNAME:-example.com}/
+# --dns-servers 8.8.8.8 (ideal curl flag) is not available in default build
+until curl --connect-timeout 1 http://${SERVERNAME:-example.com}/; do
+    echo Request to http://${SERVERNAME:-example.com}/ failed.  Until Nginx is visible at this DNS, certificate verification will not pass.
+    echo Let\'s Encrypt uses Google\'s DNS servers.  If you have already updated your DNS host, you can flush the Google DNS cache by completing the form at https://developers.google.com/speed/public-dns/cache
+    sleep 15s
+done
+echo Something is responding at  http://${SERVERNAME:-example.com}/
+
 while true; do
 
     if certbot certonly --non-interactive --webroot -w /usr/share/nginx/html --agree-tos \

--- a/services.d/certbot/run
+++ b/services.d/certbot/run
@@ -18,7 +18,7 @@ echo Nginx has arrived.
 echo Waiting for a response from http://${SERVERNAME:-example.com}/
 # --dns-servers 8.8.8.8 (ideal curl flag) is not available in default build
 until curl --connect-timeout 1 http://${SERVERNAME:-example.com}/; do
-    echo Request to http://${SERVERNAME:-example.com}/ failed.  Until Nginx is visible at this DNS, certificate verification will not pass.
+    echo Request to http://${SERVERNAME:-example.com}/ failed.  Until Nginx is visible at this DNS, certificate verification cannot succeed.  To avoid hitting rate limits, this check will repeat every 15s until resolved.
     echo Let\'s Encrypt uses Google\'s DNS servers.  If you have already updated your DNS host, you can flush the Google DNS cache by completing the form at https://developers.google.com/speed/public-dns/cache
     sleep 15s
 done


### PR DESCRIPTION
This is an initial effort to resolve #19 by ensuring that something is responding at the requested domain before proceeding to the Let's Encrypt step.  This should reduce the odds of tripping rate limits while the DNS is improperly configured (e.g. when new AWS ECS tasks are assigned arbitrary IP addresses).

I've tested this in ECS and it's working.  If a server cannot connect to itself at its own DNS entry, this check will forever fail.  It may make sense to add support for an environment variable like SKIP_DNS_CHECK that may be called to skip this section (but my bash-fu is weak so I did not attempt it).